### PR TITLE
fixed transformers version issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We present **URSA** (**U**niform disc**R**ete diffu**S**ion with metric p**A**th
 
 Clone this repository to local disk and install:
 ```bash
-pip install diffusers transformers accelerate imageio imageio-ffmpeg omegaconf wandb
+pip install diffusers transformers>=4.57.1 accelerate imageio imageio-ffmpeg omegaconf wandb
 git clone https://github.com/baaivision/URSA.git
 cd URSA && pip install .
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch
 diffusers
-transformers
+transformers>=4.57.1
 accelerate
 imageio
 imageio-ffmpeg


### PR DESCRIPTION
If we use transformers <4.57.1, the following error will arise:
`
ModuleNotFoundError: No module named 'transformers.models.qwen3'`